### PR TITLE
Support for Shapely 2.0

### DIFF
--- a/geog/geog.py
+++ b/geog/geog.py
@@ -15,6 +15,8 @@ def _to_arrays(*args):
     single = True
     for a, ndim in args:
         try:
+            arg = np.array(a.coords, copy=False)
+        except AttributeError:
             arg = np.array(a, copy=False)
         except TypeError:
             # Typically end up in here when list of Shapely geometries is


### PR DESCRIPTION
ShapelyDeprecationWarning: The array interface is deprecated and will no longer work in Shapely 2.0. Convert the '.coords' to a numpy array instead.